### PR TITLE
put interceptor decorators in auth controller and module

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import {
   Post,
   Request,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 
 import { SignInDto } from './dtos/sign-in.dto';
@@ -20,9 +21,11 @@ import { AuthGuard } from '@nestjs/passport';
 import { ConfirmPasswordDto } from './dtos/confirm-password.dto';
 import { ForgotPasswordDto } from './dtos/forgot-password.dto';
 import { ApiTags } from '@nestjs/swagger';
+import { CurrentUserInterceptor } from '../interceptors/current-user.interceptor';
 
 @ApiTags('Auth')
 @Controller('auth')
+@UseInterceptors(CurrentUserInterceptor)
 export class AuthController {
   constructor(
     private authService: AuthService,

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { User } from '../users/user.entity';
 import { JwtStrategy } from './jwt.strategy';
+import { CurrentUserInterceptor } from '../interceptors/current-user.interceptor';
 
 @Module({
   imports: [
@@ -14,6 +15,6 @@ import { JwtStrategy } from './jwt.strategy';
     PassportModule.register({ defaultStrategy: 'jwt' }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, UsersService, JwtStrategy],
+  providers: [AuthService, UsersService, JwtStrategy, CurrentUserInterceptor],
 })
 export class AuthModule {}


### PR DESCRIPTION
### ℹ️ Issue

Closes #19 

### 📝 Description

I imported the already-created CurrentUserInterceptor interceptor, added a UseInterceptor decorator in the the auth controller which uses the CurrentUserInterceptor, and added CurrentUserInterceptor as a provider in the auth module.

### ✔️ Verification

Was not sure if I required tests for this, there are barely any routes at the moment so not sure if there is much to test. But after comparing to past projects, it seems like to implement Cognito route authentication, you only need to add the interceptor to the controller via UseInterceptor() and as a provider in the module. Can create real tests if needed!

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!

A lot of the implementation for Cognito auth was already put in place by what I believe is the scaffolding, i.e. users controller and module both already had the correct decorator and providers in place. In the future, I think this ticket can get phased out entirely, or maybe put at the end once all the routes are added?