### PR TITLE
add back pills to application table

### DIFF
--- a/apps/frontend/src/components/ApplicationTable.test.tsx
+++ b/apps/frontend/src/components/ApplicationTable.test.tsx
@@ -17,7 +17,7 @@ const mockApplications: ApplicationRow[] = [
     actualStartDate: '2026-02-01',
     discipline: 'RN',
     applicantType: 'Learner',
-    status: 'App submitted',
+    status: 'App Submitted',
   },
   {
     appId: 2,
@@ -58,7 +58,7 @@ describe('ApplicationTable', () => {
     expect(screen.getByText('Social Work')).toBeDefined();
     expect(screen.getByText('Learner')).toBeDefined();
     expect(screen.getByText('Volunteer')).toBeDefined();
-    expect(screen.getByText('App submitted')).toBeDefined();
+    expect(screen.getByText('Submitted')).toBeDefined();
     expect(screen.getByText('Accepted')).toBeDefined();
   });
 

--- a/apps/frontend/src/components/ApplicationTable.tsx
+++ b/apps/frontend/src/components/ApplicationTable.tsx
@@ -1,5 +1,6 @@
 import { Table } from '@chakra-ui/react';
 import type { ApplicationRow } from '@hooks/useApplications';
+import StatusPill, { StatusPillConfig, StatusVariant } from './StatusPill';
 
 const COLUMNS = [
   'Name',
@@ -101,7 +102,11 @@ export function ApplicationTable({
               {formatDesiredExperience(application.desiredExperience)}
             </Table.Cell>
             <Table.Cell>{application.applicantType}</Table.Cell>
-            <Table.Cell>{application.status}</Table.Cell>
+            <Table.Cell>
+              <StatusPill variant={application.status as StatusVariant}>
+                {StatusPillConfig[application.status as StatusVariant].label}
+              </StatusPill>
+            </Table.Cell>
           </Table.Row>
         ))}
       </Table.Body>

--- a/apps/frontend/src/components/StatusPill.tsx
+++ b/apps/frontend/src/components/StatusPill.tsx
@@ -1,14 +1,14 @@
 import { Button } from '@chakra-ui/react';
 
 export enum StatusVariant {
-  APP_SUBMITTED = 'submitted',
-  IN_REVIEW = 'review',
-  FORMS_SENT = 'formsSent',
-  ACCEPTED = 'accepted',
-  DECLINED = 'declined',
-  NO_AVAILABILITY = 'noAvailability',
-  ACTIVE = 'active',
-  INACTIVE = 'inactive',
+  APP_SUBMITTED = 'App Submitted',
+  IN_REVIEW = 'In Review',
+  FORMS_SIGNED = 'Forms Signed',
+  ACCEPTED = 'Accepted',
+  DECLINED = 'Declined',
+  NO_AVAILABILITY = 'No Availability',
+  ACTIVE = 'Active',
+  INACTIVE = 'Inactive',
 }
 
 type StatusPillProps = {
@@ -20,42 +20,42 @@ export const StatusPillConfig: Record<
   StatusVariant,
   { label: string; background: string; border: string }
 > = {
-  submitted: {
+  [StatusVariant.APP_SUBMITTED]: {
     label: 'Submitted',
     background: '#FFF9E6',
     border: '#B8AF98',
   },
-  review: {
+  [StatusVariant.IN_REVIEW]: {
     label: 'Review',
     background: '#DBEAFE',
     border: '#2563EB',
   },
-  formsSent: {
-    label: 'Forms Sent',
+  [StatusVariant.FORMS_SIGNED]: {
+    label: 'Forms Signed',
     background: '#E9D5FF',
     border: '#9333EA',
   },
-  accepted: {
+  [StatusVariant.ACCEPTED]: {
     label: 'Accepted',
     background: '#F1F7EC',
     border: '#6AB242',
   },
-  declined: {
+  [StatusVariant.DECLINED]: {
     label: 'Declined',
     background: '#FFD1D2',
     border: '#E91E21',
   },
-  noAvailability: {
+  [StatusVariant.NO_AVAILABILITY]: {
     label: 'No Availability',
     background: '#0000004D',
     border: '#000000',
   },
-  active: {
+  [StatusVariant.ACTIVE]: {
     label: 'Active',
     background: '#A7F3D0',
     border: '#047857',
   },
-  inactive: {
+  [StatusVariant.INACTIVE]: {
     label: 'Inactive',
     background: '#F1F5F9',
     border: '#686868',


### PR DESCRIPTION
### ℹ️ Issue

Adds back pills


### ✔️ Verification

<img width="1429" height="730" alt="Screenshot 2026-04-18 at 12 09 39 AM" src="https://github.com/user-attachments/assets/4cc22387-6e78-4dc3-9d80-48db9bf6d3ae" />



### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!

The as StatusVariant cast is technically a lie at the type level so if the backend ever returns a status not in the enum, it will crash the site. To make it honest, we should change ApplicationRow.status from string to AppStatus (imported from @api/types) and then drop the cast. Since StatusVariant now has the same string values as AppStatus, they're interchangeable at runtime.
