### PR TITLE
Dashboard card prop colors

### DIFF
--- a/apps/frontend/src/components/DashboardCard.tsx
+++ b/apps/frontend/src/components/DashboardCard.tsx
@@ -7,6 +7,7 @@ export type DashboardCardProps = {
   icon: string;
   title: string;
   value: number;
+  color: string;
 };
 
 export default function DashboardCard({
@@ -15,13 +16,14 @@ export default function DashboardCard({
   description,
   icon,
   className,
+  color,
 }: DashboardCardProps) {
   return (
     <Card.Root
       borderRadius="18px"
       borderWidth="2px"
       borderColor="black"
-      bg="white"
+      bg={color}
       pl={3}
       pr={3}
       className={className}

--- a/apps/frontend/src/containers/AdminLanding.tsx
+++ b/apps/frontend/src/containers/AdminLanding.tsx
@@ -71,6 +71,7 @@ const AdminLanding: React.FC = () => {
             value={totalCount}
             description="All time submissions"
             icon={usersIcon}
+            color="#FFF9E6"
           />
 
           <DashboardCard
@@ -79,6 +80,7 @@ const AdminLanding: React.FC = () => {
             value={inReviewCount}
             description="Awaiting decision"
             icon={clockIcon}
+            color="#DBEAFE"
           />
 
           <DashboardCard
@@ -87,6 +89,7 @@ const AdminLanding: React.FC = () => {
             value={rejectedCount}
             description="Not matched"
             icon={crossIcon}
+            color="#FFD1D2"
           />
 
           <DashboardCard
@@ -95,6 +98,7 @@ const AdminLanding: React.FC = () => {
             value={approvedCount}
             description="Active volunteers"
             icon={checkmarkIcon}
+            color="#d4f7e7ff"
           />
         </Box>
         <div


### PR DESCRIPTION
### ℹ️ Issue

Closes #252 

### 📝 Description

Added a new parameter in the Dashboard card prop to accept a color and applied it to the admin landing page. The colors used were the same as the ones in the status pills except for green which I made a bit of a lighter shade.

### ✔️ Verification

<img width="1202" height="657" alt="Screenshot 2026-04-23 at 1 39 36 AM" src="https://github.com/user-attachments/assets/0cec2256-08f1-4c96-8568-4df7fb398655" />

