### PR TITLE
289 alternating colors

### DIFF
--- a/apps/frontend/src/components/AvailabilityTable.tsx
+++ b/apps/frontend/src/components/AvailabilityTable.tsx
@@ -114,6 +114,7 @@ export const AvailabilityTable: React.FC<AvailabilityTableProps> = ({
             alignItems="center"
             px="6"
             py="4"
+            bg={index % 2 === 0 ? 'gray.50' : 'white'}
             borderTop={index === 0 ? 'none' : '1px solid'}
             borderColor="gray.100"
             _hover={{ bg: 'gray.50' }}

--- a/apps/frontend/src/components/QuestionFrame.tsx
+++ b/apps/frontend/src/components/QuestionFrame.tsx
@@ -5,11 +5,12 @@ interface QuestionFrameProps {
   answers: string[];
 }
 
-export const QuestionFrame: React.FC<{ frameProps: QuestionFrameProps }> = ({
+export const QuestionFrame: React.FC<{ frameProps: QuestionFrameProps, bgColor?: string }> = ({
   frameProps,
+  bgColor = 'white',
 }) => {
   return (
-    <Box borderWidth="1px" borderRadius="lg" p={6} bg="white">
+    <Box borderWidth="1px" borderRadius="lg" p={6} bg={bgColor ?? 'white'}>
       <Flex gap={4} alignItems="center" flexWrap="wrap">
         <Heading as="h2" size="md" flexShrink={0}>
           {frameProps.question}

--- a/apps/frontend/src/components/QuestionFrame.tsx
+++ b/apps/frontend/src/components/QuestionFrame.tsx
@@ -5,10 +5,10 @@ interface QuestionFrameProps {
   answers: string[];
 }
 
-export const QuestionFrame: React.FC<{ frameProps: QuestionFrameProps, bgColor?: string }> = ({
-  frameProps,
-  bgColor = 'white',
-}) => {
+export const QuestionFrame: React.FC<{
+  frameProps: QuestionFrameProps;
+  bgColor?: string;
+}> = ({ frameProps, bgColor = 'white' }) => {
   return (
     <Box borderWidth="1px" borderRadius="lg" p={6} bg={bgColor ?? 'white'}>
       <Flex gap={4} alignItems="center" flexWrap="wrap">

--- a/apps/frontend/src/containers/AdminViewApplication.tsx
+++ b/apps/frontend/src/containers/AdminViewApplication.tsx
@@ -167,6 +167,7 @@ const AdminViewApplication: React.FC = () => {
               ? [application.nonEnglishLangs]
               : [],
           }}
+          bgColor="gray.50"
         />
         {application.applicantType === ApplicantType.LEARNER &&
         learnerInfo !== null ? (
@@ -178,6 +179,7 @@ const AdminViewApplication: React.FC = () => {
                 learnerInfo.isSupervisorApplying ? 'Supervisor' : 'Myself',
               ],
             }}
+            bgColor="white"
           />
         ) : (
           <QuestionFrame
@@ -186,6 +188,7 @@ const AdminViewApplication: React.FC = () => {
                 'Are you applying for yourself or are you a supervisor/instructor?',
               answers: ['Myself'],
             }}
+            bgColor="white"
           />
         )}
         <SchoolAffiliationFrame
@@ -223,7 +226,7 @@ const AdminViewApplication: React.FC = () => {
           />
         </Box>
 
-        <Box borderWidth="1px" borderRadius="lg" p={6} bg="white">
+        <Box borderWidth="1px" borderRadius="lg" p={6} bg="gray.50">
           <Heading as="h2" size="md" mb={4}>
             Uploaded Material
           </Heading>
@@ -245,6 +248,7 @@ const AdminViewApplication: React.FC = () => {
             question: 'How did you hear about us?',
             answers: application.heardAboutFrom,
           }}
+          bgColor="white"
         />
         <EmergencyContactFrame
           name={application.emergencyContactName}

--- a/apps/frontend/src/containers/CandidateViewApplication.tsx
+++ b/apps/frontend/src/containers/CandidateViewApplication.tsx
@@ -212,6 +212,7 @@ const CandidateViewApplication: React.FC = () => {
               ? [application.nonEnglishLangs]
               : [],
           }}
+          bgColor="gray.50"
         />
         {application.applicantType === ApplicantType.LEARNER &&
         learnerInfo !== null ? (
@@ -223,6 +224,7 @@ const CandidateViewApplication: React.FC = () => {
                 learnerInfo.isSupervisorApplying ? 'Supervisor' : 'Myself',
               ],
             }}
+            bgColor="white"
           />
         ) : (
           <QuestionFrame
@@ -231,6 +233,7 @@ const CandidateViewApplication: React.FC = () => {
                 'Are you applying for yourself or are you a supervisor/instructor?',
               answers: ['Myself'],
             }}
+            bgColor="white"
           />
         )}
         <SchoolAffiliationFrame
@@ -271,7 +274,7 @@ const CandidateViewApplication: React.FC = () => {
           />
         </Box>
 
-        <Box borderWidth="1px" borderRadius="lg" p={6} bg="white">
+        <Box borderWidth="1px" borderRadius="lg" p={6} bg="gray.50">
           <Heading as="h2" size="md" mb={4}>
             Uploaded Material
           </Heading>
@@ -292,6 +295,7 @@ const CandidateViewApplication: React.FC = () => {
             question: 'How did you hear about us?',
             answers: application.heardAboutFrom,
           }}
+          bgColor="white"
         />
         <EmergencyContactFrame
           name={application.emergencyContactName}


### PR DESCRIPTION
### ℹ️ Issue

Closes #289

### 📝 Description

- Gave the individual applications alternating colors (White, Gray.50 to match the existing color scheme) in the admin and applicant views.
- Added an optional prop to the QuestionFrame component to allow for changing the background color
- Alternated colors for the Availability card (Also White, Gray.50)

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Provide screenshots of any new components, styling changes, or pages. 

Just styling changes:
Top half of application view, question frame alternates between gray.50 and white
<img width="1350" height="785" alt="Screenshot 2026-04-28 at 8 26 10 AM" src="https://github.com/user-attachments/assets/d76241a2-e002-4a2d-80eb-edeb38d32e33" />
Middle availability table: 
<img width="1354" height="438" alt="Screenshot 2026-04-28 at 8 25 57 AM" src="https://github.com/user-attachments/assets/091f687f-cf3b-4320-a772-ef619de9ea80" />
Bottom forms section background color set to gray.50
<img width="1414" height="719" alt="Screenshot 2026-04-28 at 8 27 45 AM" src="https://github.com/user-attachments/assets/2dd4ebd5-de06-405f-99ec-101183632572" />

### 🏕️ (Optional) Future Work / Notes
May want to add a border to the Additional Information card to match the rest of the components which all have borders.