### PR TITLE
Issue #313: CreatedAt/UpdatedAt to Application Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ Thumbs.db
 !example.env
 .vscode
 .postman
+
+infrastructure/params/*.json

--- a/apps/backend/src/applications/application.entity.ts
+++ b/apps/backend/src/applications/application.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 import {
   AppStatus,
@@ -275,4 +281,20 @@ export class Application {
    */
   @Column({ type: 'enum', enum: HeardAboutFrom, array: true, default: [] })
   heardAboutFrom!: HeardAboutFrom[];
+
+  /**
+   * When the application was created stored in YYYY-MM-DD format.
+   *
+   * Example: new Date('2025-01-30').
+   */
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt!: Date;
+
+  /**
+   * When the application was last updated stored in YYYY-MM-DD format.
+   *
+   * Example: new Date('2025-01-30').
+   */
+  @UpdateDateColumn({ type: 'timestamp' })
+  updatedAt!: Date;
 }

--- a/apps/backend/src/applications/application.service.spec.ts
+++ b/apps/backend/src/applications/application.service.spec.ts
@@ -55,6 +55,8 @@ const dummyApplication: Application = {
   email: 'test@example.com',
   discipline: disciplineKeys.rn,
   proposedStartDate: new Date('2024-01-01'),
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
   referred: false,
   weeklyHours: 20,
   pronouns: 'they/them',
@@ -365,6 +367,8 @@ describe('ApplicationsService', () => {
         email: 'test@example.com',
         discipline: disciplineKeys.rn,
         proposedStartDate: new Date('2024-01-01'),
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
         weeklyHours: 20,
         pronouns: 'they/them',
         nonEnglishLangs: 'none',
@@ -405,6 +409,8 @@ describe('ApplicationsService', () => {
         endDate: new Date('2024-06-30'),
         resume: 'janedoe_resume_2_6_2026.pdf',
         coverLetter: 'janedoe_coverLetter_2_6_2026.pdf',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
         actualStartDate: undefined,
       };
 
@@ -438,6 +444,8 @@ describe('ApplicationsService', () => {
         endDate: new Date('2024-06-30'),
         resume: 'janedoe_resume_2_6_2026.pdf',
         coverLetter: 'janedoe_coverLetter_2_6_2026.pdf',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
         actualStartDate: undefined,
       };
 
@@ -459,6 +467,8 @@ describe('ApplicationsService', () => {
         actualStartDate: undefined,
         resume: 'janedoe_resume_2_6_2026.pdf',
         coverLetter: 'janedoe_coverLetter_2_6_2026.pdf',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
       };
 
       mockRepository.save.mockResolvedValue(savedApplication);
@@ -479,6 +489,8 @@ describe('ApplicationsService', () => {
         actualStartDate: undefined,
         resume: 'janedoe_resume_2_6_2026.pdf',
         coverLetter: 'janedoe_coverLetter_2_6_2026.pdf',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
       };
 
       mockRepository.save.mockResolvedValue(savedApplication);
@@ -499,6 +511,8 @@ describe('ApplicationsService', () => {
         actualStartDate: undefined,
         resume: 'janedoe_resume_2_6_2026.pdf',
         coverLetter: 'janedoe_coverLetter_2_6_2026.pdf',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
       };
 
       mockRepository.save.mockResolvedValue(savedApplication);
@@ -519,6 +533,8 @@ describe('ApplicationsService', () => {
         actualStartDate: undefined,
         resume: 'janedoe_resume_2_6_2026.pdf',
         coverLetter: 'janedoe_coverLetter_2_6_2026.pdf',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
       };
 
       mockRepository.save.mockResolvedValue(savedApplication);
@@ -534,6 +550,8 @@ describe('ApplicationsService', () => {
         endDate: new Date('2024-06-30'),
         resume: 'janedoe_resume_2_6_2026.pdf',
         coverLetter: 'janedoe_coverLetter_2_6_2026.pdf',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
         actualStartDate: undefined,
       };
 
@@ -559,6 +577,8 @@ describe('ApplicationsService', () => {
         endDate: new Date('2024-06-30'),
         resume: 'janedoe_resume_2_6_2026.pdf',
         coverLetter: 'janedoe_coverLetter_2_6_2026.pdf',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
         actualStartDate: undefined,
       };
 
@@ -992,6 +1012,8 @@ describe('ApplicationsService', () => {
           interest: [InterestArea.WOMENS_HEALTH],
           license: '',
           proposedStartDate: new Date('2025-11-12'),
+          createdAt: new Date('2025-11-12'),
+          updatedAt: new Date('2025-11-12'),
           applicantType: ApplicantType.LEARNER,
           phone: '123-456-7890',
           email: 'test@example.com',
@@ -1019,6 +1041,8 @@ describe('ApplicationsService', () => {
           saturdayAvailability: 'no availability',
           interest: [InterestArea.WOMENS_HEALTH],
           proposedStartDate: new Date('2025-11-12'),
+          createdAt: new Date('2025-11-12'),
+          updatedAt: new Date('2025-11-12'),
           license: '',
           applicantType: ApplicantType.LEARNER,
           phone: '123-456-7890',

--- a/apps/backend/src/applications/applications.controller.spec.ts
+++ b/apps/backend/src/applications/applications.controller.spec.ts
@@ -109,6 +109,8 @@ const mockApplication: Application = {
   heardAboutFrom: [],
   proposedStartDate: new Date('2024-01-01'),
   endDate: new Date('2024-06-30'),
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
 };
 
 function createMockHttpHost(body: Record<string, unknown> | undefined) {

--- a/apps/backend/src/migrations/1779745897538-CreatedAtUpdatedAtApplication.ts
+++ b/apps/backend/src/migrations/1779745897538-CreatedAtUpdatedAtApplication.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreatedAtUpdatedAtApplication1779745897538
+  implements MigrationInterface
+{
+  name = 'CreatedAtUpdatedAtApplication1779745897538';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "application" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application" ADD "updatedAt" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "application" DROP COLUMN "updatedAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application" DROP COLUMN "createdAt"`,
+    );
+  }
+}

--- a/apps/backend/src/seeds/seed.ts
+++ b/apps/backend/src/seeds/seed.ts
@@ -228,7 +228,7 @@ const USER_SEED: User[] = [
   })),
 ];
 
-const APPLICATION_SEED: Application[] = [
+const APPLICATION_SEED: Partial<Application>[] = [
   {
     appId: 1,
     appStatus: AppStatus.APP_SUBMITTED,

--- a/apps/frontend/src/api/types.ts
+++ b/apps/frontend/src/api/types.ts
@@ -83,6 +83,8 @@ export interface Application extends AvailabilityFields {
   email: string;
   proposedStartDate: string;
   actualStartDate?: string;
+  createdAt: string;
+  updatedAt: string;
   discipline: string;
   otherDisciplineDescription?: string;
   appStatus: AppStatus;

--- a/apps/frontend/src/components/ApplicationProfileHeader.tsx
+++ b/apps/frontend/src/components/ApplicationProfileHeader.tsx
@@ -11,6 +11,8 @@ interface ApplicationProfileHeaderProps {
   phone?: string;
   over18?: boolean;
   statusControl?: ReactNode;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 const ApplicationProfileHeader: React.FC<ApplicationProfileHeaderProps> = ({
@@ -22,7 +24,17 @@ const ApplicationProfileHeader: React.FC<ApplicationProfileHeaderProps> = ({
   phone,
   over18,
   statusControl,
+  createdAt,
+  updatedAt,
 }) => {
+  const formatDate = (iso?: string) => {
+    if (!iso) return 'N/A';
+    try {
+      return new Date(iso).toLocaleDateString();
+    } catch (e) {
+      return iso;
+    }
+  };
   return (
     <Box display="flex" flexDirection="column" gap="4">
       <Box
@@ -85,6 +97,23 @@ const ApplicationProfileHeader: React.FC<ApplicationProfileHeaderProps> = ({
       >
         <Flex align="center" gap="6">
           <Box flex="1">
+            <div>
+              <Text as="span" fontWeight="semibold">
+                Submitted:
+              </Text>{' '}
+              <Text as="span" fontSize="sm" color="gray.600">
+                {formatDate(createdAt)}
+              </Text>
+            </div>
+            <div style={{ marginBottom: '12px' }}>
+              <Text as="span" fontWeight="semibold">
+                Last Updated:
+              </Text>{' '}
+              <Text as="span" fontSize="sm" color="gray.600">
+                {formatDate(updatedAt)}
+              </Text>
+            </div>
+
             <div>
               <Text as="span" fontWeight="semibold">
                 Pronouns:

--- a/apps/frontend/src/components/FilterPopUp.tsx
+++ b/apps/frontend/src/components/FilterPopUp.tsx
@@ -60,6 +60,8 @@ const FilterPopUp = ({
   const [openSections, setOpenSections] = useState<string[]>([
     'Proposed Start Date',
     'Actual Start Date',
+    'Created At Date',
+    'Updated At Date',
     'Discipline',
     'Discipline Admin Name',
     'Status',
@@ -78,6 +80,8 @@ const FilterPopUp = ({
   const filterCategories = [
     'Proposed Start Date',
     'Actual Start Date',
+    'Created At Date',
+    'Updated At Date',
     'Discipline',
     'Discipline Admin Name',
     'Status',
@@ -102,6 +106,14 @@ const FilterPopUp = ({
 
     if (category === 'Discipline Admin Name') {
       return filters.disciplineAdminNames.length;
+    }
+
+    if (category === 'Created At Date') {
+      return normalizeDateToDay(filters.createdAt) ? 1 : 0;
+    }
+
+    if (category === 'Updated At Date') {
+      return normalizeDateToDay(filters.updatedAt) ? 1 : 0;
     }
 
     return 0;
@@ -146,6 +158,14 @@ const FilterPopUp = ({
       return filters.proposedStartDateDirection ?? 'after';
     }
 
+    if (category === 'Created At Date') {
+      return filters.createdAtDirection ?? 'after';
+    }
+
+    if (category === 'Updated At Date') {
+      return filters.updatedAtDirection ?? 'after';
+    }
+
     return filters.actualStartDateDirection ?? 'after';
   }
 
@@ -156,6 +176,22 @@ const FilterPopUp = ({
       onFiltersChange({
         ...filters,
         proposedStartDateDirection: direction,
+      });
+      return;
+    }
+
+    if (category === 'Created At Date') {
+      onFiltersChange({
+        ...filters,
+        createdAtDirection: direction,
+      });
+      return;
+    }
+
+    if (category === 'Updated At Date') {
+      onFiltersChange({
+        ...filters,
+        updatedAtDirection: direction,
       });
       return;
     }
@@ -321,7 +357,9 @@ const FilterPopUp = ({
                           borderColor="gray.100"
                         >
                           {category === 'Proposed Start Date' ||
-                          category === 'Actual Start Date' ? (
+                          category === 'Actual Start Date' ||
+                          category === 'Created At Date' ||
+                          category === 'Updated At Date' ? (
                             <Stack gap="3">
                               <Box>
                                 <Flex align="center" gap="2">
@@ -366,7 +404,11 @@ const FilterPopUp = ({
                                 value={
                                   category === 'Proposed Start Date'
                                     ? filters.proposedStartDate ?? ''
-                                    : filters.actualStartDate ?? ''
+                                    : category === 'Actual Start Date'
+                                    ? filters.actualStartDate ?? ''
+                                    : category === 'Created At Date'
+                                    ? filters.createdAt ?? ''
+                                    : filters.updatedAt ?? ''
                                 }
                                 onChange={(e) =>
                                   category === 'Proposed Start Date'
@@ -374,9 +416,19 @@ const FilterPopUp = ({
                                         ...filters,
                                         proposedStartDate: e.target.value,
                                       })
-                                    : onFiltersChange({
+                                    : category === 'Actual Start Date'
+                                    ? onFiltersChange({
                                         ...filters,
                                         actualStartDate: e.target.value,
+                                      })
+                                    : category === 'Created At Date'
+                                    ? onFiltersChange({
+                                        ...filters,
+                                        createdAt: e.target.value,
+                                      })
+                                    : onFiltersChange({
+                                        ...filters,
+                                        updatedAt: e.target.value,
                                       })
                                 }
                                 _focus={{

--- a/apps/frontend/src/containers/AdminViewApplication.tsx
+++ b/apps/frontend/src/containers/AdminViewApplication.tsx
@@ -231,6 +231,8 @@ const AdminViewApplication: React.FC = () => {
           discipline={discipline}
           email={application.email || 'N/A'}
           phone={application.phone || 'N/A'}
+          createdAt={application.createdAt}
+          updatedAt={application.updatedAt}
           over18={learnerInfo?.isLegalAdult}
           statusControl={
             <ApplicantStageControl

--- a/apps/frontend/src/containers/CandidateViewApplication.tsx
+++ b/apps/frontend/src/containers/CandidateViewApplication.tsx
@@ -29,6 +29,14 @@ const CandidateViewApplication: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const pronouns = application?.pronouns;
   const discipline = application?.discipline;
+  const formatDate = (iso?: string) => {
+    if (!iso) return 'N/A';
+    try {
+      return new Date(iso).toLocaleString();
+    } catch (e) {
+      return iso;
+    }
+  };
   const uploadedDocuments: DocumentDownloadItem[] = [
     {
       variant: 'resume',
@@ -210,6 +218,8 @@ const CandidateViewApplication: React.FC = () => {
           discipline={discipline}
           email={application.email || 'N/A'}
           phone={application.phone || 'N/A'}
+          createdAt={application.createdAt}
+          updatedAt={application.updatedAt}
           over18={learnerInfo?.isLegalAdult}
         />
         <QuestionFrame

--- a/apps/frontend/src/hooks/useApplications.ts
+++ b/apps/frontend/src/hooks/useApplications.ts
@@ -17,6 +17,8 @@ export interface ApplicationRow {
   desiredExperience: string;
   applicantType: string;
   status: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface UseApplicationsResult {
@@ -50,6 +52,8 @@ function toRows(
       desiredExperience: app.desiredExperience,
       applicantType: app.applicantType,
       status: app.appStatus,
+      createdAt: app.createdAt,
+      updatedAt: app.updatedAt,
     };
   });
 }

--- a/apps/frontend/src/utils/applicationFilters.ts
+++ b/apps/frontend/src/utils/applicationFilters.ts
@@ -6,6 +6,10 @@ export type ApplicationFilters = {
   proposedStartDateDirection?: DateFilterDirection;
   actualStartDate?: string;
   actualStartDateDirection?: DateFilterDirection;
+  createdAt?: string;
+  createdAtDirection?: DateFilterDirection;
+  updatedAt?: string;
+  updatedAtDirection?: DateFilterDirection;
 };
 
 export type DateFilterDirection = 'before' | 'after';
@@ -18,6 +22,10 @@ export const EMPTY_APPLICATION_FILTERS: ApplicationFilters = {
   proposedStartDateDirection: 'after',
   actualStartDate: undefined,
   actualStartDateDirection: 'after',
+  createdAt: undefined,
+  createdAtDirection: 'after',
+  updatedAt: undefined,
+  updatedAtDirection: 'after',
 };
 
 interface FilterableApplication {
@@ -26,6 +34,8 @@ interface FilterableApplication {
   disciplineAdminName: string;
   proposedStartDate: string;
   actualStartDate: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface SearchableApplication extends FilterableApplication {
@@ -119,7 +129,9 @@ export function countActiveFilters(filters: ApplicationFilters): number {
     filters.disciplines.length +
     filters.disciplineAdminNames.length +
     (normalizeDateToDay(filters.proposedStartDate) ? 1 : 0) +
-    (normalizeDateToDay(filters.actualStartDate) ? 1 : 0)
+    (normalizeDateToDay(filters.actualStartDate) ? 1 : 0) +
+    (normalizeDateToDay(filters.createdAt) ? 1 : 0) +
+    (normalizeDateToDay(filters.updatedAt) ? 1 : 0)
   );
 }
 
@@ -135,9 +147,13 @@ export function compileApplicationSearchPredicate(
   return (application: SearchableApplication): boolean => {
     const proposedIso = normalizeDateToDay(application.proposedStartDate);
     const actualIso = normalizeDateToDay(application.actualStartDate);
+    const createdIso = normalizeDateToDay(application.createdAt);
+    const updatedIso = normalizeDateToDay(application.updatedAt);
 
     const proposedFormatted = formatIsoToMmddyyyy(proposedIso);
     const actualFormatted = formatIsoToMmddyyyy(actualIso);
+    const createdFormatted = formatIsoToMmddyyyy(createdIso);
+    const updatedFormatted = formatIsoToMmddyyyy(updatedIso);
     const normalizedHaystacks = [
       application.name,
       application.email,
@@ -150,6 +166,10 @@ export function compileApplicationSearchPredicate(
       proposedFormatted,
       actualIso,
       actualFormatted,
+      createdIso,
+      createdFormatted,
+      updatedIso,
+      updatedFormatted,
     ]
       .filter((value): value is string => !!value)
       .map((value) => normalizeText(value));
@@ -210,6 +230,9 @@ export function compileApplicationFilterPredicate(
   );
   const normalizedActualFilter = normalizeDateToDay(filters.actualStartDate);
 
+  const normalizedCreatedFilter = normalizeDateToDay(filters.createdAt);
+  const normalizedUpdatedFilter = normalizeDateToDay(filters.updatedAt);
+
   return (application: FilterableApplication): boolean => {
     if (
       allowedStatuses &&
@@ -253,6 +276,32 @@ export function compileApplicationFilterPredicate(
         normalizedActualApplicationDate,
         normalizedActualFilter,
         filters.actualStartDateDirection,
+      )
+    ) {
+      return false;
+    }
+
+    const normalizedCreatedApplicationDate = normalizeDateToDay(
+      application.createdAt,
+    );
+    if (
+      !matchesDateDirection(
+        normalizedCreatedApplicationDate,
+        normalizedCreatedFilter,
+        filters.createdAtDirection,
+      )
+    ) {
+      return false;
+    }
+
+    const normalizedUpdatedApplicationDate = normalizeDateToDay(
+      application.updatedAt,
+    );
+    if (
+      !matchesDateDirection(
+        normalizedUpdatedApplicationDate,
+        normalizedUpdatedFilter,
+        filters.updatedAtDirection,
       )
     ) {
       return false;


### PR DESCRIPTION
### ℹ️ Issue

Closes <#313>

### 📝 Description

Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

Added a CreatedAt and UpdatedAt to the Application schema so that admins can know when applications were first submitted and when they were last "transitioned" or changed/ looked at. Additionally, added a filter on the Admin landing page in the applicant search that allows the admin to search for applications based on their createdAt and updatedAt date. 

Briefly list the changes made to the code:
1. Edited the Application schema to have a CreatedAt and UpdatedAt column, and performed a migration for that database change --> added the new migration into the migrations folder
2. Edited the FilterPopUp and actual ApplicationFilter in the frontend to have the two new filter CreatedAt and UpdatedAt, based off of the already existing ProposedStartDate and ActualStartDate filters.

### ✔️ Verification

Tested it locally on computer. Ensured both CreatedAt and UpdatedAt worked as they should, checked that the data and filtering was correct through pgAdmin and console.

### 🏕️ (Optional) Future Work / Notes

N/A--> Only addition is that Sam worked on some additional changes I am unaware of - Angie