### PR TITLE
326 aws cognito account creation flow using temporary password for candidates

### DIFF
--- a/apps/backend/src/applications/application.service.spec.ts
+++ b/apps/backend/src/applications/application.service.spec.ts
@@ -17,6 +17,7 @@ import { UsersService } from '../users/users.service';
 import { CandidateInfoService } from '../candidate-info/candidate-info.service';
 import { AWSS3Service } from '../util/aws-s3/aws-s3.service';
 import { DisciplinesService } from '../disciplines/disciplines.service';
+import { CandidateProvisioningService } from './candidate-provisioning.service';
 
 jest.mock('../util/aws-exports', () => ({
   __esModule: true,
@@ -156,6 +157,10 @@ describe('ApplicationsService', () => {
     uploadWithKey: jest.fn(),
   };
 
+  const mockCandidateProvisioningService = {
+    provisionSubmittedCandidate: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -183,6 +188,10 @@ describe('ApplicationsService', () => {
         {
           provide: AWSS3Service,
           useValue: mockS3Service,
+        },
+        {
+          provide: CandidateProvisioningService,
+          useValue: mockCandidateProvisioningService,
         },
       ],
     }).compile();
@@ -662,20 +671,43 @@ describe('ApplicationsService', () => {
         actualStartDate: undefined,
       };
 
+      mockRepository.count.mockResolvedValue(0);
       mockRepository.save.mockResolvedValue(savedApplication);
 
       const result = await service.create(dummyCreateApplicationDto);
 
       expect(repository.save).toHaveBeenCalled();
       expect(result).toEqual(savedApplication);
-      expect(mockEmailService.queueEmail).toHaveBeenCalledWith(
-        savedApplication.email,
-        'Your Application Has Been Received',
-        expect.stringContaining('Thank you for submitting'),
-      );
+      expect(
+        mockCandidateProvisioningService.provisionSubmittedCandidate,
+      ).toHaveBeenCalledWith(savedApplication, true);
     });
 
-    it('should pass along email service errors without information loss', async () => {
+    it('should provision repeat applicants without first-time credentials', async () => {
+      const savedApplication: Application = {
+        appId: 4,
+        ...dummyCreateApplicationDto,
+        email: 'jane.doe@example.com',
+        proposedStartDate: new Date('2024-01-01'),
+        endDate: new Date('2024-06-30'),
+        resume: 'janedoe_resume_2_6_2026.pdf',
+        coverLetter: 'janedoe_coverLetter_2_6_2026.pdf',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        actualStartDate: undefined,
+      };
+
+      mockRepository.count.mockResolvedValue(2);
+      mockRepository.save.mockResolvedValue(savedApplication);
+
+      await service.create(dummyCreateApplicationDto);
+
+      expect(
+        mockCandidateProvisioningService.provisionSubmittedCandidate,
+      ).toHaveBeenCalledWith(savedApplication, false);
+    });
+
+    it('should pass along candidate provisioning errors without information loss', async () => {
       const savedApplication: Application = {
         appId: 3,
         ...dummyCreateApplicationDto,
@@ -689,8 +721,9 @@ describe('ApplicationsService', () => {
         actualStartDate: undefined,
       };
 
+      mockRepository.count.mockResolvedValue(0);
       mockRepository.save.mockResolvedValue(savedApplication);
-      mockEmailService.queueEmail.mockRejectedValueOnce(
+      mockCandidateProvisioningService.provisionSubmittedCandidate.mockRejectedValueOnce(
         new Error('Failed to send email'),
       );
 

--- a/apps/backend/src/applications/applications.module.ts
+++ b/apps/backend/src/applications/applications.module.ts
@@ -13,6 +13,8 @@ import { CandidateInfoService } from '../candidate-info/candidate-info.service';
 import { CandidateInfo } from '../candidate-info/candidate-info.entity';
 import { EmailService } from '../util/email/email.service';
 import { DisciplinesModule } from '../disciplines/disciplines.module';
+import { CandidateProvisioningService } from './candidate-provisioning.service';
+import { cognitoIdentityProviderFactory } from '../admin-provisioning/cognito.provider';
 
 @Module({
   imports: [
@@ -26,6 +28,8 @@ import { DisciplinesModule } from '../disciplines/disciplines.module';
   controllers: [ApplicationsController],
   providers: [
     ApplicationsService,
+    CandidateProvisioningService,
+    cognitoIdentityProviderFactory,
     CandidateInfoService,
     EmailService,
     CurrentUserInterceptor,

--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -15,6 +15,7 @@ import { UsersService } from '../users/users.service';
 import { CandidateInfoService } from '../candidate-info/candidate-info.service';
 import { AWSS3Service } from '../util/aws-s3/aws-s3.service';
 import { DisciplinesService } from '../disciplines/disciplines.service';
+import { CandidateProvisioningService } from './candidate-provisioning.service';
 import { User } from '../users/user.entity';
 import { LearnerInfo } from '../learner-info/learner-info.entity';
 
@@ -224,6 +225,7 @@ export class ApplicationsService {
     private candidateInfoService: CandidateInfoService,
     private awsS3Service: AWSS3Service,
     private disciplinesService: DisciplinesService,
+    private candidateProvisioningService: CandidateProvisioningService,
   ) {}
 
   /**
@@ -679,31 +681,23 @@ export class ApplicationsService {
     createApplicationDto: CreateApplicationDto,
   ): Promise<Application> {
     this.validateApplicationDto(createApplicationDto);
+    const normalizedEmail = createApplicationDto.email.trim().toLowerCase();
+    const existingApplicationCount = await this.applicationRepository.count({
+      where: { email: normalizedEmail },
+    });
     const normalizedDiscipline = await this.validateDiscipline(
       createApplicationDto.discipline,
     );
     const application = this.applicationRepository.create({
       ...createApplicationDto,
+      email: normalizedEmail,
       discipline: normalizedDiscipline,
     });
     const saved = await this.applicationRepository.save(application);
 
-    const name = String(saved.email).split('@')[0];
-    const applicantName = name
-      .split('.')
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(' ');
-
-    const emailBody = `<p>Hello ${applicantName},</p>
-
-      <p>Thank you for submitting your application! You can now create an account here on the portal to track your status. Please use the same name and email as your application.</p>
-
-      <p>Thank you,<br/>BHCHP</p>`;
-
-    await this.emailService.queueEmail(
-      saved.email,
-      'Your Application Has Been Received',
-      emailBody,
+    await this.candidateProvisioningService.provisionSubmittedCandidate(
+      saved,
+      existingApplicationCount === 0,
     );
 
     return saved;

--- a/apps/backend/src/applications/candidate-provisioning.service.spec.ts
+++ b/apps/backend/src/applications/candidate-provisioning.service.spec.ts
@@ -1,0 +1,191 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminCreateUserCommand } from '@aws-sdk/client-cognito-identity-provider';
+import { CandidateProvisioningService } from './candidate-provisioning.service';
+import { COGNITO_IDENTITY_PROVIDER } from '../admin-provisioning/cognito.provider';
+import { EmailService } from '../util/email/email.service';
+import { CandidateInfoService } from '../candidate-info/candidate-info.service';
+import { UsersService } from '../users/users.service';
+import { UserType } from '../users/types';
+import { Application } from './application.entity';
+import {
+  AppStatus,
+  ApplicantType,
+  DesiredExperience,
+  InterestArea,
+} from './types';
+
+jest.mock('../util/aws-exports', () => ({
+  __esModule: true,
+  default: {
+    AWSConfig: {
+      region: 'us-east-2',
+    },
+    CognitoAuthConfig: {
+      userPoolId: 'test-user-pool-id',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+    },
+    PublicFrontendUrl: 'https://frontend.example.com',
+  },
+}));
+
+describe('CandidateProvisioningService', () => {
+  let service: CandidateProvisioningService;
+
+  const mockCognitoIdentityProvider = {
+    send: jest.fn(),
+  };
+
+  const mockEmailService = {
+    queueEmail: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockCandidateInfoService = {
+    create: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockUsersService = {
+    findOne: jest.fn().mockResolvedValue(null),
+    create: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const application: Application = {
+    appId: 10,
+    appStatus: AppStatus.APP_SUBMITTED,
+    mondayAvailability: 'morning',
+    tuesdayAvailability: 'morning',
+    wednesdayAvailability: 'morning',
+    thursdayAvailability: 'morning',
+    fridayAvailability: 'morning',
+    saturdayAvailability: 'none',
+    interest: [InterestArea.WOMENS_HEALTH],
+    license: '',
+    applicantType: ApplicantType.LEARNER,
+    phone: '123-456-7890',
+    email: 'jane.doe@example.com',
+    discipline: 'rn',
+    proposedStartDate: new Date('2024-01-01'),
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    referred: false,
+    weeklyHours: 20,
+    pronouns: 'they/them',
+    nonEnglishLangs: 'spanish',
+    desiredExperience: DesiredExperience.PRE_LICENSURE_PLACEMENT,
+    resume: 'resume.pdf',
+    coverLetter: 'cover-letter.pdf',
+    confidentialityForm: undefined,
+    emergencyContactName: 'Jane Doe',
+    emergencyContactPhone: '111-111-1111',
+    emergencyContactRelationship: 'Mother',
+    heardAboutFrom: [],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CandidateProvisioningService,
+        {
+          provide: COGNITO_IDENTITY_PROVIDER,
+          useValue: mockCognitoIdentityProvider,
+        },
+        {
+          provide: EmailService,
+          useValue: mockEmailService,
+        },
+        {
+          provide: CandidateInfoService,
+          useValue: mockCandidateInfoService,
+        },
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CandidateProvisioningService>(
+      CandidateProvisioningService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('provisions a new candidate account and sends a temporary password for first-time applicants', async () => {
+    mockCognitoIdentityProvider.send.mockResolvedValue({});
+
+    await service.provisionSubmittedCandidate(application, true);
+
+    expect(mockCognitoIdentityProvider.send).toHaveBeenCalledTimes(1);
+    const command = mockCognitoIdentityProvider.send.mock.calls[0][0];
+    expect(command).toBeInstanceOf(AdminCreateUserCommand);
+    expect(command.input).toMatchObject({
+      UserPoolId: 'test-user-pool-id',
+      Username: 'jane.doe@example.com',
+      MessageAction: 'SUPPRESS',
+    });
+    expect(mockUsersService.create).toHaveBeenCalledWith(
+      'jane.doe@example.com',
+      'Jane',
+      'Doe',
+      UserType.STANDARD,
+    );
+    expect(mockCandidateInfoService.create).toHaveBeenCalledWith(
+      application.appId,
+      'jane.doe@example.com',
+    );
+    expect(mockEmailService.queueEmail).toHaveBeenCalledWith(
+      'jane.doe@example.com',
+      'Your application has been submitted',
+      expect.stringContaining('Temporary password:'),
+    );
+    expect(mockEmailService.queueEmail).toHaveBeenCalledWith(
+      'jane.doe@example.com',
+      'Your application has been submitted',
+      expect.stringContaining('https://frontend.example.com/login'),
+    );
+  });
+
+  it('sends the submission email without a temporary password for repeat applicants', async () => {
+    await service.provisionSubmittedCandidate(application, false);
+
+    expect(mockCognitoIdentityProvider.send).not.toHaveBeenCalled();
+    expect(mockCandidateInfoService.create).toHaveBeenCalledWith(
+      application.appId,
+      'jane.doe@example.com',
+    );
+    expect(mockEmailService.queueEmail).toHaveBeenCalledWith(
+      'jane.doe@example.com',
+      'Your application has been submitted',
+      expect.not.stringContaining('Temporary password:'),
+    );
+    expect(mockUsersService.create).toHaveBeenCalledWith(
+      'jane.doe@example.com',
+      'Jane',
+      'Doe',
+      UserType.STANDARD,
+    );
+  });
+
+  it('falls back to a login-link-only email when the candidate already has a Cognito account', async () => {
+    mockCognitoIdentityProvider.send.mockRejectedValue(
+      new Error('UsernameExistsException'),
+    );
+
+    await service.provisionSubmittedCandidate(application, true);
+
+    expect(mockUsersService.create).toHaveBeenCalledWith(
+      'jane.doe@example.com',
+      'Jane',
+      'Doe',
+      UserType.STANDARD,
+    );
+    expect(mockEmailService.queueEmail).toHaveBeenCalledWith(
+      'jane.doe@example.com',
+      'Your application has been submitted',
+      expect.not.stringContaining('Temporary password:'),
+    );
+  });
+});

--- a/apps/backend/src/applications/candidate-provisioning.service.ts
+++ b/apps/backend/src/applications/candidate-provisioning.service.ts
@@ -1,0 +1,193 @@
+import {
+  AdminCreateUserCommand,
+  CognitoIdentityProviderClient,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { randomBytes } from 'crypto';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Application } from './application.entity';
+import { COGNITO_IDENTITY_PROVIDER } from '../admin-provisioning/cognito.provider';
+import envConfig from '../util/aws-exports';
+import { EmailService } from '../util/email/email.service';
+import { CandidateInfoService } from '../candidate-info/candidate-info.service';
+import { UsersService } from '../users/users.service';
+import { UserType } from '../users/types';
+
+@Injectable()
+export class CandidateProvisioningService {
+  private readonly logger = new Logger(CandidateProvisioningService.name);
+
+  constructor(
+    @Inject(COGNITO_IDENTITY_PROVIDER)
+    private readonly cognitoIdentityProvider: CognitoIdentityProviderClient,
+    private readonly emailService: EmailService,
+    private readonly candidateInfoService: CandidateInfoService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  private getCognitoUserPoolId(): string {
+    const userPoolId = envConfig.CognitoAuthConfig.userPoolId;
+
+    if (!userPoolId) {
+      throw new Error(
+        'Missing COGNITO_USER_POOL_ID or VITE_COGNITO_USER_POOL_ID.',
+      );
+    }
+
+    return userPoolId;
+  }
+
+  private getPublicLoginUrl(): string {
+    const frontendUrl = envConfig.PublicFrontendUrl;
+
+    if (!frontendUrl) {
+      throw new Error(
+        'Missing PUBLIC_FRONTEND_URL or VITE_PUBLIC_FRONTEND_URL.',
+      );
+    }
+
+    return frontendUrl.endsWith('/')
+      ? `${frontendUrl}login`
+      : `${frontendUrl}/login`;
+  }
+
+  private toTitleCase(value: string): string {
+    return value
+      .split(/[^a-zA-Z0-9]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+      .join(' ');
+  }
+
+  private deriveNameParts(email: string): {
+    firstName: string;
+    lastName: string;
+  } {
+    const localPart = email.split('@')[0] ?? 'Applicant';
+    const segments = localPart.split(/[._-]+/).filter(Boolean);
+    const firstName =
+      this.toTitleCase(segments[0] ?? 'Applicant') || 'Applicant';
+    const lastName =
+      this.toTitleCase(segments.slice(1).join(' ')) || 'Applicant';
+
+    return { firstName, lastName };
+  }
+
+  private generateTemporaryPassword(): string {
+    const randomSegment = randomBytes(12).toString('base64url');
+    return `Bhchp-${randomSegment}Aa1!`;
+  }
+
+  private async createCandidateUserInCognito(
+    email: string,
+    temporaryPassword: string,
+  ): Promise<void> {
+    const command = new AdminCreateUserCommand({
+      UserPoolId: this.getCognitoUserPoolId(),
+      Username: email,
+      TemporaryPassword: temporaryPassword,
+      MessageAction: 'SUPPRESS',
+      UserAttributes: [
+        { Name: 'email', Value: email },
+        { Name: 'email_verified', Value: 'true' },
+      ],
+    });
+
+    await this.cognitoIdentityProvider.send(command);
+  }
+
+  private async ensureStandardUser(email: string): Promise<void> {
+    const existingUser = await this.usersService.findOne(email);
+    if (existingUser) {
+      return;
+    }
+
+    const { firstName, lastName } = this.deriveNameParts(email);
+    await this.usersService.create(
+      email,
+      firstName,
+      lastName,
+      UserType.STANDARD,
+    );
+  }
+
+  private isUsernameExistsError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+      return false;
+    }
+
+    return error.message.includes('UsernameExistsException');
+  }
+
+  private buildSubmissionEmailBody(
+    email: string,
+    loginUrl: string,
+    temporaryPassword?: string,
+  ): string {
+    const { firstName } = this.deriveNameParts(email);
+    const passwordBlock = temporaryPassword
+      ? `<p><strong>Temporary password:</strong> ${temporaryPassword}</p>
+
+            <p>We created your applicant account so you can log in and track your status.</p>`
+      : `<p>You can log in with your existing applicant account to track your status.</p>`;
+
+    return `
+            <p>Hello ${firstName},</p>
+
+            <p>Your application has been submitted successfully.</p>
+
+            ${passwordBlock}
+
+            <p><a href="${loginUrl}">Sign in to your account</a></p>
+
+            <p>Or copy and paste this link into your browser:</p>
+            <p><a href="${loginUrl}">${loginUrl}</a></p>
+
+            <p>If you did not submit this application, you can ignore this email.</p>
+          `;
+  }
+
+  async provisionSubmittedCandidate(
+    application: Application,
+    isFirstApplication: boolean,
+  ): Promise<void> {
+    const normalizedEmail = application.email.trim().toLowerCase();
+    const loginUrl = this.getPublicLoginUrl();
+    let temporaryPassword: string | undefined;
+
+    if (isFirstApplication) {
+      temporaryPassword = this.generateTemporaryPassword();
+
+      try {
+        await this.createCandidateUserInCognito(
+          normalizedEmail,
+          temporaryPassword,
+        );
+        await this.ensureStandardUser(normalizedEmail);
+      } catch (error) {
+        if (this.isUsernameExistsError(error)) {
+          this.logger.warn(
+            `Candidate Cognito user already exists for ${normalizedEmail}; sending login link without temporary password.`,
+          );
+          temporaryPassword = undefined;
+          await this.ensureStandardUser(normalizedEmail);
+        } else {
+          throw error;
+        }
+      }
+    } else {
+      await this.ensureStandardUser(normalizedEmail);
+    }
+
+    await this.candidateInfoService.create(application.appId, normalizedEmail);
+
+    await this.emailService.queueEmail(
+      normalizedEmail,
+      'Your application has been submitted',
+      this.buildSubmissionEmailBody(
+        normalizedEmail,
+        loginUrl,
+        temporaryPassword,
+      ),
+    );
+  }
+}

--- a/apps/frontend/src/components/QuestionFrame.tsx
+++ b/apps/frontend/src/components/QuestionFrame.tsx
@@ -16,22 +16,23 @@ export const QuestionFrame: React.FC<{
           {frameProps.question}
         </Heading>
         <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} gap={2}>
-          {frameProps.answers.map((answer) => (
-            <Button
-              borderRadius="full"
-              px={4}
-              py={3}
-              minW="auto"
-              w="fit-content"
-              bg="#008CA7"
-              color="white"
-              fontFamily="Poppins, sans-serif"
-              border="1px solid #013594"
-              key={answer}
-            >
-              {answer}
-            </Button>
-          ))}
+          {frameProps.answers &&
+            frameProps.answers.map((answer) => (
+              <Button
+                borderRadius="full"
+                px={4}
+                py={3}
+                minW="auto"
+                w="fit-content"
+                bg="#008CA7"
+                color="white"
+                fontFamily="Poppins, sans-serif"
+                border="1px solid #013594"
+                key={answer}
+              >
+                {answer}
+              </Button>
+            ))}
         </SimpleGrid>
       </Flex>
     </Box>

--- a/apps/frontend/src/containers/login.tsx
+++ b/apps/frontend/src/containers/login.tsx
@@ -225,7 +225,7 @@ const Login: React.FC = () => {
             </Heading>
             <Text color="gray.600">
               {isNewPasswordRequired
-                ? 'Create a new password to finish signing in with your invited admin account.'
+                ? 'Create a new password to finish signing in with your new account.'
                 : 'Use your Cognito account to continue.'}
             </Text>
 


### PR DESCRIPTION
### ℹ️ Issue

Closes #326 

### 📝 Description

Uses the same model of account creation for candidates as admins, except:
1. Triggers upon application creation endpoint being called
2. Emails temporary password only if it's the candidate's first time submitting an application, else it will just tell the application to login with their existing account while linking the account.