### PR TITLE
314 add internal admin notes field to application records

### DIFF
--- a/apps/backend/src/applications/application.entity.ts
+++ b/apps/backend/src/applications/application.entity.ts
@@ -297,4 +297,12 @@ export class Application {
    */
   @UpdateDateColumn({ type: 'timestamp' })
   updatedAt!: Date;
+
+  /**
+   * Internal notes about the application, only visible to admins.
+   *
+   * Example: "Applicant is potentially a good fit."
+   */
+  @Column({ type: 'varchar', nullable: true })
+  internalNotes?: string;
 }

--- a/apps/backend/src/applications/application.service.spec.ts
+++ b/apps/backend/src/applications/application.service.spec.ts
@@ -70,6 +70,7 @@ const dummyApplication: Application = {
   emergencyContactPhone: '111-111-1111',
   emergencyContactRelationship: 'Mother',
   heardAboutFrom: [],
+  internalNotes: undefined,
 };
 
 const dummyCreateApplicationDto: CreateApplicationDto = {
@@ -1064,6 +1065,86 @@ describe('ApplicationsService', () => {
       await expect(service.updateEndDate(1, updatedEndDate)).rejects.toThrow(
         'There was a problem saving the info',
       );
+    });
+  });
+
+  describe('updateInternalNotes', () => {
+    it('should update internal notes', async () => {
+      const updatedApplication: Application = {
+        ...dummyApplication,
+        internalNotes: 'Applicant is potentially a good fit.',
+      };
+
+      mockRepository.findOne.mockResolvedValue(dummyApplication);
+      mockRepository.save.mockResolvedValue(updatedApplication);
+
+      const result = await service.updateInternalNotes(
+        1,
+        'Applicant is potentially a good fit.',
+      );
+
+      expect(result).toEqual(updatedApplication);
+      expect(repository.findOne).toHaveBeenCalledWith({ where: { appId: 1 } });
+      expect(repository.save).toHaveBeenCalledWith({
+        ...dummyApplication,
+        internalNotes: 'Applicant is potentially a good fit.',
+      });
+    });
+
+    it('should clear internal notes when undefined is passed', async () => {
+      const updatedApplication: Application = {
+        ...dummyApplication,
+        internalNotes: undefined,
+      };
+
+      mockRepository.findOne.mockResolvedValue(dummyApplication);
+      mockRepository.save.mockResolvedValue(updatedApplication);
+
+      const result = await service.updateInternalNotes(1, undefined);
+
+      expect(result).toEqual(updatedApplication);
+      expect(repository.save).toHaveBeenCalledWith({
+        ...dummyApplication,
+        internalNotes: undefined,
+      });
+    });
+
+    it('should throw NotFoundException if application is not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateInternalNotes(
+          999,
+          'Applicant is potentially a good fit.',
+        ),
+      ).rejects.toThrow('Application with ID 999 not found');
+    });
+
+    it('should throw BadRequestException if application id is missing', async () => {
+      await expect(
+        service.updateInternalNotes(0, 'Applicant is potentially a good fit.'),
+      ).rejects.toThrow('Application ID is required');
+    });
+
+    it('should error out without information loss if the repository throws an error during retrieval', async () => {
+      mockRepository.findOne.mockRejectedValueOnce(
+        new Error('There was a problem retrieving the info'),
+      );
+
+      await expect(
+        service.updateInternalNotes(1, 'Applicant is potentially a good fit.'),
+      ).rejects.toThrow('There was a problem retrieving the info');
+    });
+
+    it('should error out without information loss if the repository throws an error during save', async () => {
+      mockRepository.findOne.mockResolvedValue(dummyApplication);
+      mockRepository.save.mockRejectedValueOnce(
+        new Error('There was a problem saving the info'),
+      );
+
+      await expect(
+        service.updateInternalNotes(1, 'Applicant is potentially a good fit.'),
+      ).rejects.toThrow('There was a problem saving the info');
     });
   });
 

--- a/apps/backend/src/applications/applications.controller.ts
+++ b/apps/backend/src/applications/applications.controller.ts
@@ -28,6 +28,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { UpdateApplicationStatusDto } from './dto/update-application-status.request.dto';
 import { UpdateApplicationDisciplineDto } from './dto/update-application-discipline.request.dto';
 import { UpdateApplicationAvailabilityDto } from './dto/update-application-availability.request.dto';
+import { UpdateApplicationInternalNotesDto } from './dto/update-application-internal-notes.request.dto';
 import { CurrentUserInterceptor } from '../interceptors/current-user.interceptor';
 import { AuthGuard } from '@nestjs/passport';
 import { UserType } from '../users/types';
@@ -360,6 +361,26 @@ export class ApplicationsController {
     return await this.applicationsService.updateEndDate(
       appId,
       new Date(endDate),
+    );
+  }
+
+  /**
+   * Exposes an endpoint to update the internal notes of an application.
+   * @param appId The id of the application to update.
+   * @param updateInternalNotesDto Object containing the new internal notes.
+   * @returns The updated application object.
+   * @throws {NotFoundException} with message 'Application with ID <appId> not found'
+   *         if the application does not exist.
+   */
+  @Patch('/:appId/internal-notes')
+  @Roles(UserType.ADMIN)
+  async updateApplicationInternalNotes(
+    @Param('appId', ParseIntPipe) appId: number,
+    @Body() updateInternalNotesDto: UpdateApplicationInternalNotesDto,
+  ): Promise<Application> {
+    return await this.applicationsService.updateInternalNotes(
+      appId,
+      updateInternalNotesDto.internalNotes,
     );
   }
 

--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -883,6 +883,28 @@ export class ApplicationsService {
   }
 
   /**
+   * Updates the internal notes of an application.
+   * @param appId The id of the application to update.
+   * @param internalNotes The new internal notes string.
+   * @returns The updated application object.
+   * @throws {NotFoundException} if the application does not exist.
+   * @throws {Error} which is unchanged from what repository throws.
+   */
+  async updateInternalNotes(
+    appId: number,
+    internalNotes: string | undefined,
+  ): Promise<Application> {
+    if (!appId) {
+      throw new BadRequestException('Application ID is required');
+    }
+
+    const application = await this.findById(appId);
+
+    application.internalNotes = internalNotes;
+    return await this.applicationRepository.save(application);
+  }
+
+  /**
    * Deletes an application from the repository by id.
    * @param appId the id of the application to delete.
    * @throws {NotFoundException} if the application does not exist.

--- a/apps/backend/src/applications/dto/update-application-internal-notes.request.dto.ts
+++ b/apps/backend/src/applications/dto/update-application-internal-notes.request.dto.ts
@@ -1,0 +1,17 @@
+import { IsOptional, IsString } from 'class-validator';
+
+/**
+ * Defines the expected shape of data for updating an application's internal notes.
+ *
+ * DTO - data transfer object (defines and validates the structure of data sent over the network).
+ */
+export class UpdateApplicationInternalNotesDto {
+  /**
+   * Internal notes about the application, only visible to admins.
+   *
+   * Example: "Applicant is potentially a good fit."
+   */
+  @IsString()
+  @IsOptional()
+  internalNotes?: string;
+}

--- a/apps/backend/src/migrations/1781306552405-AddInternalNotesToApplications.ts
+++ b/apps/backend/src/migrations/1781306552405-AddInternalNotesToApplications.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddInternalNotesToApplications1781306552405
+  implements MigrationInterface
+{
+  name = 'AddInternalNotesToApplications1781306552405';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "application" DROP CONSTRAINT "FK_application_discipline_key"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."UQ_discipline_key"`);
+    await queryRunner.query(`DROP INDEX "public"."UQ_discipline_label"`);
+    await queryRunner.query(
+      `ALTER TABLE "application" DROP CONSTRAINT "CHK_application_desiredExperience_allowed"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application" ADD "internalNotes" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "discipline" ADD CONSTRAINT "UQ_8e7dbc4c94e2523e93a8204c9c9" UNIQUE ("key")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "discipline" ADD CONSTRAINT "UQ_c14f089503ae8aad2632abff710" UNIQUE ("label")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "discipline" DROP CONSTRAINT "UQ_c14f089503ae8aad2632abff710"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "discipline" DROP CONSTRAINT "UQ_8e7dbc4c94e2523e93a8204c9c9"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application" DROP COLUMN "internalNotes"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application" ADD CONSTRAINT "CHK_application_desiredExperience_allowed" CHECK ((("desiredExperience")::text = ANY ((ARRAY['Pre-Licensure Placement (NP/PA, Nursing, Behavioral Health, Psychiatry)'::character varying, 'Practicum'::character varying, 'Public Health Project'::character varying, 'Shadowing'::character varying, 'Volunteer/Intern'::character varying])::text[])))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "UQ_discipline_label" ON "discipline" ("label") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "UQ_discipline_key" ON "discipline" ("key") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application" ADD CONSTRAINT "FK_application_discipline_key" FOREIGN KEY ("discipline") REFERENCES "discipline"("key") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/apps/backend/src/migrations/1781306552405-AddInternalNotesToApplications.ts
+++ b/apps/backend/src/migrations/1781306552405-AddInternalNotesToApplications.ts
@@ -7,45 +7,13 @@ export class AddInternalNotesToApplications1781306552405
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "application" DROP CONSTRAINT "FK_application_discipline_key"`,
-    );
-    await queryRunner.query(`DROP INDEX "public"."UQ_discipline_key"`);
-    await queryRunner.query(`DROP INDEX "public"."UQ_discipline_label"`);
-    await queryRunner.query(
-      `ALTER TABLE "application" DROP CONSTRAINT "CHK_application_desiredExperience_allowed"`,
-    );
-    await queryRunner.query(
       `ALTER TABLE "application" ADD "internalNotes" character varying`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "discipline" ADD CONSTRAINT "UQ_8e7dbc4c94e2523e93a8204c9c9" UNIQUE ("key")`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "discipline" ADD CONSTRAINT "UQ_c14f089503ae8aad2632abff710" UNIQUE ("label")`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "discipline" DROP CONSTRAINT "UQ_c14f089503ae8aad2632abff710"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "discipline" DROP CONSTRAINT "UQ_8e7dbc4c94e2523e93a8204c9c9"`,
-    );
-    await queryRunner.query(
       `ALTER TABLE "application" DROP COLUMN "internalNotes"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "application" ADD CONSTRAINT "CHK_application_desiredExperience_allowed" CHECK ((("desiredExperience")::text = ANY ((ARRAY['Pre-Licensure Placement (NP/PA, Nursing, Behavioral Health, Psychiatry)'::character varying, 'Practicum'::character varying, 'Public Health Project'::character varying, 'Shadowing'::character varying, 'Volunteer/Intern'::character varying])::text[])))`,
-    );
-    await queryRunner.query(
-      `CREATE UNIQUE INDEX "UQ_discipline_label" ON "discipline" ("label") `,
-    );
-    await queryRunner.query(
-      `CREATE UNIQUE INDEX "UQ_discipline_key" ON "discipline" ("key") `,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "application" ADD CONSTRAINT "FK_application_discipline_key" FOREIGN KEY ("discipline") REFERENCES "discipline"("key") ON DELETE NO ACTION ON UPDATE NO ACTION`,
     );
   }
 }

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -221,6 +221,15 @@ export class ApiClient {
     }) as Promise<Application>;
   }
 
+  public async updateApplicationInternalNotes(
+    appId: number,
+    internalNotes: string | undefined,
+  ): Promise<Application> {
+    return this.patch(`/api/applications/${appId}/internal-notes`, {
+      internalNotes,
+    }) as Promise<Application>;
+  }
+
   public async getConfidentialityTemplateUrl(): Promise<ConfidentialityTemplateResponse> {
     return this.get(
       '/api/applications/forms/confidentiality/template',

--- a/apps/frontend/src/api/types.ts
+++ b/apps/frontend/src/api/types.ts
@@ -113,6 +113,7 @@ export interface Application extends AvailabilityFields {
   emergencyContactRelationship: string;
   heardAboutFrom: HeardAboutFrom[];
   endDate?: string;
+  internalNotes?: string;
 }
 
 /**

--- a/apps/frontend/src/containers/AdminViewApplication.tsx
+++ b/apps/frontend/src/containers/AdminViewApplication.tsx
@@ -4,10 +4,12 @@ import apiClient from '@api/apiClient';
 import {
   Badge,
   Box,
+  Button,
   Flex,
   Heading,
   Spinner,
   Text,
+  Textarea,
   VStack,
 } from '@chakra-ui/react';
 import AvailabilityTable from '@components/AvailabilityTable';
@@ -187,6 +189,26 @@ const AdminViewApplication: React.FC = () => {
       nextDate,
     );
     setApplication(updatedApplication);
+  };
+
+  const [internalNotes, setInternalNotes] = useState<string>(
+    application?.internalNotes ?? '',
+  );
+  const [notesSaving, setNotesSaving] = useState(false);
+
+  useEffect(() => {
+    setInternalNotes(application?.internalNotes ?? '');
+  }, [application]);
+
+  const handleInternalNotesUpdate = async () => {
+    if (!application) return;
+    setNotesSaving(true);
+    const updatedApplication = await apiClient.updateApplicationInternalNotes(
+      application.appId,
+      internalNotes,
+    );
+    setApplication(updatedApplication);
+    setNotesSaving(false);
   };
 
   if (loading) {
@@ -445,6 +467,30 @@ const AdminViewApplication: React.FC = () => {
           phone={application.emergencyContactPhone}
           relationship={application.emergencyContactRelationship}
         />
+
+        <Box borderWidth="1px" borderRadius="lg" p={6} bg="orange.50">
+          <Heading as="h2" size="md" mb={1}>
+            Internal Notes
+          </Heading>
+          <Text fontSize="sm" color="orange.700" mb={3}>
+            Admin only — not visible to applicants.
+          </Text>
+          <Textarea
+            value={internalNotes}
+            onChange={(e) => setInternalNotes(e.target.value)}
+            placeholder="Add internal notes about this applicant..."
+            bg="white"
+            rows={4}
+          />
+          <Button
+            mt={3}
+            colorScheme="orange"
+            loading={notesSaving}
+            onClick={handleInternalNotesUpdate}
+          >
+            Save Notes
+          </Button>
+        </Box>
       </Box>
     </Flex>
   );

--- a/apps/frontend/src/containers/AdminViewApplication.tsx
+++ b/apps/frontend/src/containers/AdminViewApplication.tsx
@@ -468,7 +468,7 @@ const AdminViewApplication: React.FC = () => {
           relationship={application.emergencyContactRelationship}
         />
 
-        <Box borderWidth="1px" borderRadius="lg" p={6} bg="orange.50">
+        <Box borderWidth="1px" borderRadius="lg" p={6} bg="white">
           <Heading as="h2" size="md" mb={1}>
             Internal Notes
           </Heading>

--- a/apps/frontend/src/containers/AdminViewApplication.tsx
+++ b/apps/frontend/src/containers/AdminViewApplication.tsx
@@ -2,6 +2,7 @@ import NavBar from '@components/NavBar/NavBar';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 import apiClient from '@api/apiClient';
 import {
+  Alert,
   Badge,
   Box,
   Button,
@@ -195,20 +196,41 @@ const AdminViewApplication: React.FC = () => {
     application?.internalNotes ?? '',
   );
   const [notesSaving, setNotesSaving] = useState(false);
+  const [notesSaveError, setNotesSaveError] = useState<string | null>(null);
+  const [showNotesSaved, setShowNotesSaved] = useState(false);
 
   useEffect(() => {
     setInternalNotes(application?.internalNotes ?? '');
   }, [application]);
 
+  useEffect(() => {
+    if (!showNotesSaved) return;
+
+    const t = setTimeout(() => setShowNotesSaved(false), 4500);
+    return () => clearTimeout(t);
+  }, [showNotesSaved]);
+
   const handleInternalNotesUpdate = async () => {
-    if (!application) return;
+    if (!application || notesSaving) return;
+
+    setNotesSaveError(null);
     setNotesSaving(true);
-    const updatedApplication = await apiClient.updateApplicationInternalNotes(
-      application.appId,
-      internalNotes,
-    );
-    setApplication(updatedApplication);
-    setNotesSaving(false);
+
+    try {
+      const updatedApplication = await apiClient.updateApplicationInternalNotes(
+        application.appId,
+        internalNotes,
+      );
+      setApplication(updatedApplication);
+      setShowNotesSaved(true);
+    } catch (error) {
+      console.error('[ui] AdminViewApplication notes save failed', error);
+      setNotesSaveError(
+        'We could not save internal notes. Please try again or contact support.',
+      );
+    } finally {
+      setNotesSaving(false);
+    }
   };
 
   if (loading) {
@@ -246,6 +268,43 @@ const AdminViewApplication: React.FC = () => {
         overflowY="auto"
         maxH="100vh"
       >
+        {showNotesSaved && (
+          <Box
+            position="fixed"
+            top="20px"
+            right="20px"
+            zIndex={9999}
+            bg="white"
+            border="1px solid rgba(0,0,0,0.08)"
+            boxShadow="0 6px 18px rgba(0,0,0,0.12)"
+            borderRadius="8px"
+            px="16px"
+            py="10px"
+            display="flex"
+            alignItems="center"
+            gap="12px"
+          >
+            <Box
+              width="28px"
+              height="28px"
+              borderRadius="full"
+              bg="#E7EEFF"
+              color="#4C6EDB"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              fontSize="14px"
+            >
+              !
+            </Box>
+            <Box>
+              <Text fontWeight="700">Notes saved</Text>
+              <Text fontSize="12px">
+                Internal notes have been successfully updated.
+              </Text>
+            </Box>
+          </Box>
+        )}
         <ApplicationProfileHeader
           firstName={user ? user.firstName : ''}
           lastName={user ? user.lastName : ''}
@@ -475,9 +534,21 @@ const AdminViewApplication: React.FC = () => {
           <Text fontSize="sm" color="orange.700" mb={3}>
             Admin only — not visible to applicants.
           </Text>
+          {notesSaveError && (
+            <Alert.Root status="error" mb={3}>
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Title>Failed to save notes</Alert.Title>
+                <Alert.Description>{notesSaveError}</Alert.Description>
+              </Alert.Content>
+            </Alert.Root>
+          )}
           <Textarea
             value={internalNotes}
-            onChange={(e) => setInternalNotes(e.target.value)}
+            onChange={(e) => {
+              setInternalNotes(e.target.value);
+              setNotesSaveError(null);
+            }}
             placeholder="Add internal notes about this applicant..."
             bg="white"
             rows={4}


### PR DESCRIPTION
### ℹ️ Issue

Closes <#314>

### 📝 Description

Added an internal notes field to application records that is only visible to admins.

Briefly list the changes made to the code:
1. Added internalNotes nullable column to the Application entity and generated a migration of the new database schema
2. Added a new DTO UpdateApplicationInternalNotesDto and an updateInternalNotes method to ApplicationsService w/ tests
4. Added PATCH endpoint to ApplicationsController restricted to admin users
5. Added internalNotes field to the frontend Application type and updateApplicationInternalNotes method to ApiClient
6. Added an admin-only Internal Notes UI section at the bottom of AdminViewApplication.tsx

### ✔️ Verification

Ran and tested locally using the superadmin login. Added notes, saved them, refreshed page, left page, and ensure they saved. Logged in using the standard login, and ensured that the internal notes column wasn't visible for a standard user.


https://github.com/user-attachments/assets/c0672b46-908f-4721-8420-c427d3c1da22